### PR TITLE
feat(phase 1.5): WI 29146137

### DIFF
--- a/src/acrcssc/azext_acrcssc/_help.py
+++ b/src/acrcssc/azext_acrcssc/_help.py
@@ -22,7 +22,7 @@ helps['acr supply-chain workflow create'] = """
     examples:
         - name: Create acr supply chain workflow
           text: az acr supply-chain workflow create -r $MyRegistry -g $MyResourceGroup \
-                --type continuouspatchv1 --cadence 1d --config path-to-config-file
+                --type continuouspatchv1 --schedule 1d --config path-to-config-file
 """
 helps['acr supply-chain workflow update'] = """
     type: command
@@ -30,7 +30,7 @@ helps['acr supply-chain workflow update'] = """
     examples:
         - name: Updates acr supply chain workflow
           text: az acr supply-chain workflow update -r $MyRegistry -g $MyResourceGroup --type \
-                continuouspatchv1 --cadence 1d --config path-to-config-file
+                continuouspatchv1 --schedule 1d --config path-to-config-file
 """
 
 helps['acr supply-chain workflow show'] = """

--- a/src/acrcssc/azext_acrcssc/_params.py
+++ b/src/acrcssc/azext_acrcssc/_params.py
@@ -3,12 +3,10 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 # pylint: disable=line-too-long
+from azure.cli.command_modules.acr._constants import REGISTRY_RESOURCE_TYPE
+from azure.cli.command_modules.acr._validators import validate_registry_name
 from azure.cli.core import AzCommandsLoader
 from azure.cli.core.commands.parameters import (get_resource_name_completion_list, get_three_state_flag, get_enum_type)
-
-from azure.cli.command_modules.acr._constants import REGISTRY_RESOURCE_TYPE
-
-from azure.cli.command_modules.acr._validators import validate_registry_name
 
 
 def load_arguments(self: AzCommandsLoader, _):
@@ -22,11 +20,11 @@ def load_arguments(self: AzCommandsLoader, _):
     with self.argument_context("acr supply-chain workflow create") as c:
         c.argument("config", options_list=["--config"], help="Configuration file path containing the json schema for the list of repositories and tags to filter within the registry. Schema example:{\"repositories\":[{\"repository\":\"alpine\",\"tags\":[\"tag1\",\"tag2\"],\"enabled\":true},{\"repository\":\"python\",\"tags\":[\"*\"],\"enabled\":false}], \"version\": \"v1\"}", required=True)
         c.argument("schedule", options_list=["--schedule"], help="schedule to run the scan and patching task. E.g. `<n>d` where <n> is the number of days between each run. Max value is 30d.", required=True)
-        c.argument("defer_immediate_run", options_list=["--defer-immediate-run"], help="Use this flag to defer immediately running of selected workflow task. Default value: false.", arg_type=get_three_state_flag(), required=False)
+        c.argument("run_immediately", options_list=["--run-immediately"], help="Set this flag to trigger the immediate run of the selected workflow task. Default value: false.", arg_type=get_three_state_flag(), required=False)
         c.argument("dryrun", options_list=["--dry-run"], help="Use this flag to see the qualifying repositories and tags that would be affected by the workflow. Default value: false. 'config' parameter is mandatory to provide with dry-run", arg_type=get_three_state_flag(), required=False)
 
     with self.argument_context("acr supply-chain workflow update") as c:
         c.argument("config", options_list=["--config"], help="Configuration file path containing the json schema for the list of repositories and tags to filter within the registry. Schema example:{\"repositories\":[{\"repository\":\"alpine\",\"tags\":[\"tag1\",\"tag2\"],\"enabled\":true},{\"repository\":\"python\",\"tags\":[\"*\"],\"enabled\":false}], \"version\": \"v1\"}", required=False)
         c.argument("schedule", options_list=["--schedule"], help="schedule to run the scan and patching task. E.g. `<n>d` where n is the number of days between each run. Max value is 30d.", required=False)
-        c.argument("defer_immediate_run", options_list=["--defer-immediate-run"], help="Use this flag to defer immediately running of selected workflow task. Default value: false.", arg_type=get_three_state_flag(), required=False)
+        c.argument("run_immediately", options_list=["--run-immediately"], help="Set this flag to trigger the immediate run of the selected workflow task. Default value: false.", arg_type=get_three_state_flag(), required=False)
         c.argument("dryrun", options_list=["--dry-run"], help="Use this flag to see the qualifying repositories and tags that would be affected by the workflow. Default value: false. 'config' parameter is mandatory to provide with dry-run", arg_type=get_three_state_flag(), required=False)

--- a/src/acrcssc/azext_acrcssc/_params.py
+++ b/src/acrcssc/azext_acrcssc/_params.py
@@ -21,12 +21,12 @@ def load_arguments(self: AzCommandsLoader, _):
 
     with self.argument_context("acr supply-chain workflow create") as c:
         c.argument("config", options_list=["--config"], help="Configuration file path containing the json schema for the list of repositories and tags to filter within the registry. Schema example:{\"repositories\":[{\"repository\":\"alpine\",\"tags\":[\"tag1\",\"tag2\"],\"enabled\":true},{\"repository\":\"python\",\"tags\":[\"*\"],\"enabled\":false}], \"version\": \"v1\"}", required=True)
-        c.argument("cadence", options_list=["--cadence"], help="Cadence to run the scan and patching task. E.g. `<n>d` where <n> is the number of days between each run. Max value is 30d.", required=True)
+        c.argument("schedule", options_list=["--schedule"], help="schedule to run the scan and patching task. E.g. `<n>d` where <n> is the number of days between each run. Max value is 30d.", required=True)
         c.argument("defer_immediate_run", options_list=["--defer-immediate-run"], help="Use this flag to defer immediately running of selected workflow task. Default value: false.", arg_type=get_three_state_flag(), required=False)
         c.argument("dryrun", options_list=["--dry-run"], help="Use this flag to see the qualifying repositories and tags that would be affected by the workflow. Default value: false. 'config' parameter is mandatory to provide with dry-run", arg_type=get_three_state_flag(), required=False)
 
     with self.argument_context("acr supply-chain workflow update") as c:
         c.argument("config", options_list=["--config"], help="Configuration file path containing the json schema for the list of repositories and tags to filter within the registry. Schema example:{\"repositories\":[{\"repository\":\"alpine\",\"tags\":[\"tag1\",\"tag2\"],\"enabled\":true},{\"repository\":\"python\",\"tags\":[\"*\"],\"enabled\":false}], \"version\": \"v1\"}", required=False)
-        c.argument("cadence", options_list=["--cadence"], help="Cadence to run the scan and patching task. E.g. `<n>d` where n is the number of days between each run. Max value is 30d.", required=True)
+        c.argument("schedule", options_list=["--schedule"], help="schedule to run the scan and patching task. E.g. `<n>d` where n is the number of days between each run. Max value is 30d.", required=False)
         c.argument("defer_immediate_run", options_list=["--defer-immediate-run"], help="Use this flag to defer immediately running of selected workflow task. Default value: false.", arg_type=get_three_state_flag(), required=False)
         c.argument("dryrun", options_list=["--dry-run"], help="Use this flag to see the qualifying repositories and tags that would be affected by the workflow. Default value: false. 'config' parameter is mandatory to provide with dry-run", arg_type=get_three_state_flag(), required=False)

--- a/src/acrcssc/azext_acrcssc/_validators.py
+++ b/src/acrcssc/azext_acrcssc/_validators.py
@@ -21,7 +21,7 @@ from .helper._constants import (
     ERROR_MESSAGE_INVALID_TIMESPAN_VALUE,
     RESOURCE_GROUP,
     SUBSCRIPTION)
-from .helper._constants import CSSCTaskTypes, ERROR_MESSAGE_INVALID_TASK, RECOMMENDATION_CADENCE
+from .helper._constants import CSSCTaskTypes, ERROR_MESSAGE_INVALID_TASK, RECOMMENDATION_SCHEDULE
 from .helper._ociartifactoperations import _get_acr_token
 from azure.mgmt.core.tools import (parse_resource_id)
 from azure.cli.core.azclierror import InvalidArgumentValueError
@@ -104,23 +104,23 @@ def _check_task_exists(cmd, registry, task_name=""):
     return False
 
 
-def _validate_cadence(cadence):
-    # during update, cadence can be null if we are only updating the config
-    if cadence is None:
+def _validate_schedule(schedule):
+    # during update, schedule can be null if we are only updating the config
+    if schedule is None:
         return
     # Extract the numeric value and unit from the timespan expression
-    match = re.match(r'(\d+)(d)$', cadence)
+    match = re.match(r'(\d+)(d)$', schedule)
     if not match:
-        raise InvalidArgumentValueError(error_msg=ERROR_MESSAGE_INVALID_TIMESPAN_FORMAT, recommendation=RECOMMENDATION_CADENCE)
+        raise InvalidArgumentValueError(error_msg=ERROR_MESSAGE_INVALID_TIMESPAN_FORMAT, recommendation=RECOMMENDATION_SCHEDULE)
     if match is not None:
         value = int(match.group(1))
         unit = match.group(2)
     if unit == 'd' and (value < 1 or value > 30):  # day of the month
-        raise InvalidArgumentValueError(error_msg=ERROR_MESSAGE_INVALID_TIMESPAN_VALUE, recommendation=RECOMMENDATION_CADENCE)
+        raise InvalidArgumentValueError(error_msg=ERROR_MESSAGE_INVALID_TIMESPAN_VALUE, recommendation=RECOMMENDATION_SCHEDULE)
 
 
-def validate_inputs(cadence, config_file_path=None):
-    _validate_cadence(cadence)
+def validate_inputs(schedule, config_file_path=None):
+    _validate_schedule(schedule)
     if config_file_path is not None:
         validate_continuouspatch_config_v1(config_file_path)
 
@@ -130,6 +130,6 @@ def validate_task_type(task_type):
         raise InvalidArgumentValueError(error_msg=ERROR_MESSAGE_INVALID_TASK)
 
 
-def validate_cssc_optional_inputs(cssc_config_path, cadence):
-    if cssc_config_path is None and cadence is None:
-        raise InvalidArgumentValueError(error_msg="Provide at least one parameter to update: --cadence or --config")
+def validate_cssc_optional_inputs(cssc_config_path, schedule):
+    if cssc_config_path is None and schedule is None:
+        raise InvalidArgumentValueError(error_msg="Provide at least one parameter to update: --schedule or --config")

--- a/src/acrcssc/azext_acrcssc/_validators.py
+++ b/src/acrcssc/azext_acrcssc/_validators.py
@@ -16,6 +16,7 @@ from .helper._constants import (
     CONTINUOSPATCH_OCI_ARTIFACT_CONFIG,
     CONTINUOUSPATCH_CONFIG_SCHEMA_V1,
     CONTINUOUSPATCH_CONFIG_SCHEMA_SIZE_LIMIT,
+    CONTINUOUSPATCH_CONFIG_SUPPORTED_VERSIONS,
     CONTINUOSPATCH_ALL_TASK_NAMES,
     ERROR_MESSAGE_INVALID_TIMESPAN_FORMAT,
     ERROR_MESSAGE_INVALID_TIMESPAN_VALUE,
@@ -71,6 +72,8 @@ def _validate_continuouspatch_config(config):
                 raise InvalidArgumentValueError(f"Configuration error: Repository {repository['repository']} Tag {tag} is not allowed. Tags ending with '*-patched' (floating tag) or '*-[0-9]\\{{1,3}}' (incremental tag) are reserved for internal use.")
             if tag == "*" and len(repository.get("tags", [])) > 1:
                 raise InvalidArgumentValueError("Configuration error: Tag '*' is not allowed with other tags in the same repository. Use '*' as the only tag in the repository to avoid overlaps.")
+    if config.get("version","") not in CONTINUOUSPATCH_CONFIG_SUPPORTED_VERSIONS:
+        raise InvalidArgumentValueError(f"Configuration error: Version {config.get('version','')} is not supported. Supported versions are {CONTINUOUSPATCH_CONFIG_SUPPORTED_VERSIONS}")
 
 
 def check_continuous_task_exists(cmd, registry):

--- a/src/acrcssc/azext_acrcssc/cssc.py
+++ b/src/acrcssc/azext_acrcssc/cssc.py
@@ -26,23 +26,23 @@ def _perform_continuous_patch_operation(cmd,
                                         resource_group_name,
                                         registry_name,
                                         config,
-                                        cadence,
+                                        schedule,
                                         dryrun=False,
                                         defer_immediate_run=False,
                                         is_create=True):
     acr_client_registries = cf_acr_registries(cmd.cli_ctx, None)
     registry = acr_client_registries.get(resource_group_name, registry_name)
 
-    validate_inputs(cadence, config)
+    validate_inputs(schedule, config)
 
     if not is_create:
-        validate_cssc_optional_inputs(config, cadence)
+        validate_cssc_optional_inputs(config, schedule)
 
     logger.debug('validations completed successfully.')
     if dryrun:
         acr_cssc_dry_run(cmd, registry=registry, config_file_path=config, is_create=is_create)
     else:
-        create_update_continuous_patch_v1(cmd, registry, config, cadence, dryrun, defer_immediate_run, is_create)
+        create_update_continuous_patch_v1(cmd, registry, config, schedule, dryrun, defer_immediate_run, is_create)
 
 
 def create_acrcssc(cmd,
@@ -50,16 +50,16 @@ def create_acrcssc(cmd,
                    registry_name,
                    workflow_type,
                    config,
-                   cadence,
+                   schedule,
                    dryrun=False,
                    defer_immediate_run=False):
     '''Create a continuous patch task in the registry.'''
-    logger.debug(f"Entering create_acrcssc with parameters: {registry_name} {workflow_type} {config} {cadence} {dryrun}")
+    logger.debug(f"Entering create_acrcssc with parameters: {registry_name} {workflow_type} {config} {schedule} {dryrun}")
     _perform_continuous_patch_operation(cmd,
                                         resource_group_name,
                                         registry_name,
                                         config,
-                                        cadence,
+                                        schedule,
                                         dryrun,
                                         defer_immediate_run,
                                         is_create=True)
@@ -70,16 +70,16 @@ def update_acrcssc(cmd,
                    registry_name,
                    workflow_type,
                    config,
-                   cadence,
+                   schedule,
                    dryrun=False,
                    defer_immediate_run=False):
     '''Update a continuous patch task in the registry.'''
-    logger.debug(f'Entering update_acrcssc with parameters: {registry_name} {workflow_type} {config} {cadence} {dryrun} {defer_immediate_run}')
+    logger.debug(f'Entering update_acrcssc with parameters: {registry_name} {workflow_type} {config} {schedule} {dryrun} {defer_immediate_run}')
     _perform_continuous_patch_operation(cmd,
                                         resource_group_name,
                                         registry_name,
                                         config,
-                                        cadence,
+                                        schedule,
                                         dryrun,
                                         defer_immediate_run,
                                         is_create=False)

--- a/src/acrcssc/azext_acrcssc/cssc.py
+++ b/src/acrcssc/azext_acrcssc/cssc.py
@@ -28,7 +28,7 @@ def _perform_continuous_patch_operation(cmd,
                                         config,
                                         schedule,
                                         dryrun=False,
-                                        defer_immediate_run=False,
+                                        run_immediately=False,
                                         is_create=True):
     acr_client_registries = cf_acr_registries(cmd.cli_ctx, None)
     registry = acr_client_registries.get(resource_group_name, registry_name)
@@ -42,7 +42,7 @@ def _perform_continuous_patch_operation(cmd,
     if dryrun:
         acr_cssc_dry_run(cmd, registry=registry, config_file_path=config, is_create=is_create)
     else:
-        create_update_continuous_patch_v1(cmd, registry, config, schedule, dryrun, defer_immediate_run, is_create)
+        create_update_continuous_patch_v1(cmd, registry, config, schedule, dryrun, run_immediately, is_create)
 
 
 def create_acrcssc(cmd,
@@ -52,7 +52,7 @@ def create_acrcssc(cmd,
                    config,
                    schedule,
                    dryrun=False,
-                   defer_immediate_run=False):
+                   run_immediately=False):
     '''Create a continuous patch task in the registry.'''
     logger.debug(f"Entering create_acrcssc with parameters: {registry_name} {workflow_type} {config} {schedule} {dryrun}")
     _perform_continuous_patch_operation(cmd,
@@ -61,7 +61,7 @@ def create_acrcssc(cmd,
                                         config,
                                         schedule,
                                         dryrun,
-                                        defer_immediate_run,
+                                        run_immediately,
                                         is_create=True)
 
 
@@ -72,16 +72,16 @@ def update_acrcssc(cmd,
                    config,
                    schedule,
                    dryrun=False,
-                   defer_immediate_run=False):
+                   run_immediately=False):
     '''Update a continuous patch task in the registry.'''
-    logger.debug(f'Entering update_acrcssc with parameters: {registry_name} {workflow_type} {config} {schedule} {dryrun} {defer_immediate_run}')
+    logger.debug(f'Entering update_acrcssc with parameters: {registry_name} {workflow_type} {config} {schedule} {dryrun} {run_immediately}')
     _perform_continuous_patch_operation(cmd,
                                         resource_group_name,
                                         registry_name,
                                         config,
                                         schedule,
                                         dryrun,
-                                        defer_immediate_run,
+                                        run_immediately,
                                         is_create=False)
 
 

--- a/src/acrcssc/azext_acrcssc/helper/_constants.py
+++ b/src/acrcssc/azext_acrcssc/helper/_constants.py
@@ -70,6 +70,7 @@ ERROR_MESSAGE_INVALID_TIMESPAN_FORMAT = "Schedule format is invalid. "
 RECOMMENDATION_SCHEDULE = "Schedule must be in the format of <number><unit> where unit is d for days. Example: 1d. Max value for d is 30d."
 # this dictionary can be expanded to handle more configuration of the tasks regarding continuous patching
 # if this gets out of hand, or more types of tasks are supported, this should be a class on its own
+# BUG: this structure should be merged with 'CONTINUOUS_PATCH_WORKFLOW' dictionary. Ideally model it as a class
 CONTINUOSPATCH_TASK_DEFINITION = {
     CONTINUOSPATCH_TASK_PATCHIMAGE_NAME:
         {
@@ -88,6 +89,7 @@ CONTINUOSPATCH_TASK_DEFINITION = {
         },
 }
 CONTINUOUSPATCH_CONFIG_SCHEMA_SIZE_LIMIT = 1024 * 1024 * 10  # 10MB, we don't want to allow huge files
+CONTINUOUSPATCH_CONFIG_SUPPORTED_VERSIONS = ["v1"]
 CONTINUOUSPATCH_CONFIG_SCHEMA_V1 = {
     "type": "object",
     "properties": {

--- a/src/acrcssc/azext_acrcssc/helper/_constants.py
+++ b/src/acrcssc/azext_acrcssc/helper/_constants.py
@@ -94,6 +94,10 @@ CONTINUOUSPATCH_CONFIG_SCHEMA_V1 = {
         "version": {
             "type": "string",
         },
+        "tag-convention": {
+            "type": "string",
+            "pattern": "(?i)floating|incremental"
+        },
         "repositories": {
             "type": "array",
             "items": {

--- a/src/acrcssc/azext_acrcssc/helper/_constants.py
+++ b/src/acrcssc/azext_acrcssc/helper/_constants.py
@@ -39,7 +39,7 @@ CONTINUOUSPATCH_TASK_PATCHIMAGE_DESCRIPTION = "This task will patch the OS vulne
 CONTINUOSPATCH_TASK_SCANIMAGE_NAME = "cssc-scan-image"
 CONTINUOUSPATCH_TASK_SCANIMAGE_DESCRIPTION = f"This task will perform vulnerability OS scan on a given image using Trivy. If there are any vulnerabilities found, it will trigger the patching task using {CONTINUOSPATCH_TASK_PATCHIMAGE_NAME} task."
 CONTINUOSPATCH_TASK_SCANREGISTRY_NAME = "cssc-trigger-workflow"
-CONTINUOUSPATCH_TASK_SCANREGISTRY_DESCRIPTION = f"This task will trigger the coninuous patching workflow based on the cadence set during the creation. It will match the filter repositories set with config parameter and schedule vulnerability scan check using {CONTINUOSPATCH_TASK_SCANIMAGE_NAME} task."
+CONTINUOUSPATCH_TASK_SCANREGISTRY_DESCRIPTION = f"This task will trigger the coninuous patching workflow based on the schedule set during the creation. It will match the filter repositories set with config parameter and schedule vulnerability scan check using {CONTINUOSPATCH_TASK_SCANIMAGE_NAME} task."
 CONTINUOUS_PATCHING_WORKFLOW_NAME = "continuouspatchv1"
 DESCRIPTION = "Description"
 TASK_RUN_STATUS_FAILED = "Failed"
@@ -65,9 +65,9 @@ CONTINUOUS_PATCH_WORKFLOW = {
 }
 
 ERROR_MESSAGE_INVALID_TASK = "Workflow type is invalid"
-ERROR_MESSAGE_INVALID_TIMESPAN_VALUE = "Cadence value is invalid. "
-ERROR_MESSAGE_INVALID_TIMESPAN_FORMAT = "Cadence format is invalid. "
-RECOMMENDATION_CADENCE = "Cadence must be in the format of <number><unit> where unit is d for days. Example: 1d. Max value for d is 30d."
+ERROR_MESSAGE_INVALID_TIMESPAN_VALUE = "Schedule value is invalid. "
+ERROR_MESSAGE_INVALID_TIMESPAN_FORMAT = "Schedule format is invalid. "
+RECOMMENDATION_SCHEDULE = "Schedule must be in the format of <number><unit> where unit is d for days. Example: 1d. Max value for d is 30d."
 # this dictionary can be expanded to handle more configuration of the tasks regarding continuous patching
 # if this gets out of hand, or more types of tasks are supported, this should be a class on its own
 CONTINUOSPATCH_TASK_DEFINITION = {

--- a/src/acrcssc/azext_acrcssc/helper/_taskoperations.py
+++ b/src/acrcssc/azext_acrcssc/helper/_taskoperations.py
@@ -47,8 +47,8 @@ logger = get_logger(__name__)
 DEFAULT_CHUNK_SIZE = 1024 * 4
 
 
-def create_update_continuous_patch_v1(cmd, registry, cssc_config_file, schedule, dryrun, defer_immediate_run, is_create_workflow=True):
-    logger.debug(f"Entering continuousPatchV1_creation {cssc_config_file} {dryrun} {defer_immediate_run}")
+def create_update_continuous_patch_v1(cmd, registry, cssc_config_file, schedule, dryrun, run_immediately, is_create_workflow=True):
+    logger.debug(f"Entering continuousPatchV1_creation {cssc_config_file} {dryrun} {run_immediately}")
     resource_group = parse_resource_id(registry.id)[RESOURCE_GROUP]
     schedule_cron_expression = None
     if schedule is not None:
@@ -68,7 +68,7 @@ def create_update_continuous_patch_v1(cmd, registry, cssc_config_file, schedule,
         create_oci_artifact_continuous_patch(registry, cssc_config_file, dryrun)
         logger.debug(f"Uploading of {cssc_config_file} completed successfully.")
 
-    _eval_trigger_run(cmd, registry, resource_group, defer_immediate_run)
+    _eval_trigger_run(cmd, registry, resource_group, run_immediately)
 
 
 def _create_cssc_workflow(cmd, registry, schedule_cron_expression, resource_group, dry_run):
@@ -101,8 +101,8 @@ def _update_cssc_workflow(cmd, registry, schedule_cron_expression, resource_grou
         _update_task_schedule(cmd, registry, schedule_cron_expression, resource_group, dry_run)
 
 
-def _eval_trigger_run(cmd, registry, resource_group, defer_immediate_run):
-    if not defer_immediate_run:
+def _eval_trigger_run(cmd, registry, resource_group, run_immediately):
+    if run_immediately:
         logger.warning(f'Triggering the {CONTINUOSPATCH_TASK_SCANREGISTRY_NAME} to run immediately')
         # Seen Managed Identity taking time, see if there can be an alternative (one alternative is to schedule the cron expression with delay)
         # NEED TO SKIP THE TIME.SLEEP IN UNIT TEST CASE OR FIND AN ALTERNATIVE SOLUITION TO MI COMPLETE

--- a/src/acrcssc/azext_acrcssc/helper/_taskoperations.py
+++ b/src/acrcssc/azext_acrcssc/helper/_taskoperations.py
@@ -72,8 +72,10 @@ def create_update_continuous_patch_v1(cmd, registry, cssc_config_file, schedule,
 
     _eval_trigger_run(cmd, registry, resource_group, run_immediately)
 
-    next_date = get_next_date(schedule_cron_expression)
-    print(f"Continuous Patching workflow scheduled to run next at: {next_date} UTC")
+    # on 'update' schedule is optional
+    if schedule is not None:
+        next_date = get_next_date(schedule_cron_expression)
+        print(f"Continuous Patching workflow scheduled to run next at: {next_date} UTC")
 
 
 def _create_cssc_workflow(cmd, registry, schedule_cron_expression, resource_group, dry_run):

--- a/src/acrcssc/azext_acrcssc/helper/_utility.py
+++ b/src/acrcssc/azext_acrcssc/helper/_utility.py
@@ -14,9 +14,9 @@ logger = get_logger(__name__)
 # pylint: disable=logging-fstring-interpolation
 
 
-def convert_timespan_to_cron(cadence, date_time=None):
+def convert_timespan_to_cron(schedule, date_time=None):
     # Regex to look for pattern 1d, 2d, 3d, etc.
-    match = re.match(r'(\d+)([d])', cadence)
+    match = re.match(r'(\d+)([d])', schedule)
     value = int(match.group(1))
     unit = match.group(2)
 
@@ -34,7 +34,7 @@ def convert_timespan_to_cron(cadence, date_time=None):
     return cron_expression
 
 
-def transform_cron_to_cadence(cron_expression):
+def transform_cron_to_schedule(cron_expression):
     parts = cron_expression.split()
     # The third part of the cron expression
     third_part = parts[2]

--- a/src/acrcssc/azext_acrcssc/tests/latest/recordings/test_create_supplychain_workflow.yaml
+++ b/src/acrcssc/azext_acrcssc/tests/latest/recordings/test_create_supplychain_workflow.yaml
@@ -204,7 +204,7 @@ interactions:
       Connection:
       - keep-alive
       ParameterSetName:
-      - -g -t -r --config --cadence --defer-immediate-run
+      - -g -t -r --config --schedule --defer-immediate-run
       User-Agent:
       - AZURECLI/2.61.0 azsdk-python-core/1.30.2 Python/3.8.10 (Windows-10-10.0.22631-SP0)
     method: GET
@@ -250,7 +250,7 @@ interactions:
       Connection:
       - keep-alive
       ParameterSetName:
-      - -g -t -r --config --cadence --defer-immediate-run
+      - -g -t -r --config --schedule --defer-immediate-run
       User-Agent:
       - AZURECLI/2.61.0 azsdk-python-core/1.30.2 Python/3.8.10 (Windows-10-10.0.22631-SP0)
     method: GET
@@ -298,7 +298,7 @@ interactions:
       Connection:
       - keep-alive
       ParameterSetName:
-      - -g -t -r --config --cadence --defer-immediate-run
+      - -g -t -r --config --schedule --defer-immediate-run
       User-Agent:
       - AZURECLI/2.61.0 azsdk-python-core/1.30.2 Python/3.8.10 (Windows-10-10.0.22631-SP0)
     method: GET
@@ -346,7 +346,7 @@ interactions:
       Connection:
       - keep-alive
       ParameterSetName:
-      - -g -t -r --config --cadence --defer-immediate-run
+      - -g -t -r --config --schedule --defer-immediate-run
       User-Agent:
       - AZURECLI/2.61.0 azsdk-python-core/1.30.2 Python/3.8.10 (Windows-10-10.0.22631-SP0)
     method: GET
@@ -448,7 +448,7 @@ interactions:
       Content-Type:
       - application/json
       ParameterSetName:
-      - -g -t -r --config --cadence --defer-immediate-run
+      - -g -t -r --config --schedule --defer-immediate-run
       User-Agent:
       - AZURECLI/2.61.0 azsdk-python-core/1.30.2 Python/3.8.10 (Windows-10-10.0.22631-SP0)
     method: POST
@@ -549,7 +549,7 @@ interactions:
       Content-Type:
       - application/json
       ParameterSetName:
-      - -g -t -r --config --cadence --defer-immediate-run
+      - -g -t -r --config --schedule --defer-immediate-run
       User-Agent:
       - AZURECLI/2.61.0 azsdk-python-core/1.30.2 Python/3.8.10 (Windows-10-10.0.22631-SP0)
     method: PUT
@@ -598,7 +598,7 @@ interactions:
       Connection:
       - keep-alive
       ParameterSetName:
-      - -g -t -r --config --cadence --defer-immediate-run
+      - -g -t -r --config --schedule --defer-immediate-run
       User-Agent:
       - AZURECLI/2.61.0 azsdk-python-core/1.30.2 Python/3.8.10 (Windows-10-10.0.22631-SP0)
     method: GET
@@ -642,7 +642,7 @@ interactions:
       Connection:
       - keep-alive
       ParameterSetName:
-      - -g -t -r --config --cadence --defer-immediate-run
+      - -g -t -r --config --schedule --defer-immediate-run
       User-Agent:
       - AZURECLI/2.61.0 azsdk-python-core/1.30.2 Python/3.8.10 (Windows-10-10.0.22631-SP0)
     method: GET
@@ -686,7 +686,7 @@ interactions:
       Connection:
       - keep-alive
       ParameterSetName:
-      - -g -t -r --config --cadence --defer-immediate-run
+      - -g -t -r --config --schedule --defer-immediate-run
       User-Agent:
       - AZURECLI/2.61.0 azsdk-python-core/1.30.2 Python/3.8.10 (Windows-10-10.0.22631-SP0)
     method: GET

--- a/src/acrcssc/azext_acrcssc/tests/latest/recordings/test_create_supplychain_workflow.yaml
+++ b/src/acrcssc/azext_acrcssc/tests/latest/recordings/test_create_supplychain_workflow.yaml
@@ -204,7 +204,7 @@ interactions:
       Connection:
       - keep-alive
       ParameterSetName:
-      - -g -t -r --config --schedule --defer-immediate-run
+      - -g -t -r --config --schedule
       User-Agent:
       - AZURECLI/2.61.0 azsdk-python-core/1.30.2 Python/3.8.10 (Windows-10-10.0.22631-SP0)
     method: GET
@@ -250,7 +250,7 @@ interactions:
       Connection:
       - keep-alive
       ParameterSetName:
-      - -g -t -r --config --schedule --defer-immediate-run
+      - -g -t -r --config --schedule
       User-Agent:
       - AZURECLI/2.61.0 azsdk-python-core/1.30.2 Python/3.8.10 (Windows-10-10.0.22631-SP0)
     method: GET
@@ -298,7 +298,7 @@ interactions:
       Connection:
       - keep-alive
       ParameterSetName:
-      - -g -t -r --config --schedule --defer-immediate-run
+      - -g -t -r --config --schedule
       User-Agent:
       - AZURECLI/2.61.0 azsdk-python-core/1.30.2 Python/3.8.10 (Windows-10-10.0.22631-SP0)
     method: GET
@@ -346,7 +346,7 @@ interactions:
       Connection:
       - keep-alive
       ParameterSetName:
-      - -g -t -r --config --schedule --defer-immediate-run
+      - -g -t -r --config --schedule
       User-Agent:
       - AZURECLI/2.61.0 azsdk-python-core/1.30.2 Python/3.8.10 (Windows-10-10.0.22631-SP0)
     method: GET
@@ -448,7 +448,7 @@ interactions:
       Content-Type:
       - application/json
       ParameterSetName:
-      - -g -t -r --config --schedule --defer-immediate-run
+      - -g -t -r --config --schedule
       User-Agent:
       - AZURECLI/2.61.0 azsdk-python-core/1.30.2 Python/3.8.10 (Windows-10-10.0.22631-SP0)
     method: POST
@@ -549,7 +549,7 @@ interactions:
       Content-Type:
       - application/json
       ParameterSetName:
-      - -g -t -r --config --schedule --defer-immediate-run
+      - -g -t -r --config --schedule
       User-Agent:
       - AZURECLI/2.61.0 azsdk-python-core/1.30.2 Python/3.8.10 (Windows-10-10.0.22631-SP0)
     method: PUT
@@ -598,7 +598,7 @@ interactions:
       Connection:
       - keep-alive
       ParameterSetName:
-      - -g -t -r --config --schedule --defer-immediate-run
+      - -g -t -r --config --schedule
       User-Agent:
       - AZURECLI/2.61.0 azsdk-python-core/1.30.2 Python/3.8.10 (Windows-10-10.0.22631-SP0)
     method: GET
@@ -642,7 +642,7 @@ interactions:
       Connection:
       - keep-alive
       ParameterSetName:
-      - -g -t -r --config --schedule --defer-immediate-run
+      - -g -t -r --config --schedule
       User-Agent:
       - AZURECLI/2.61.0 azsdk-python-core/1.30.2 Python/3.8.10 (Windows-10-10.0.22631-SP0)
     method: GET
@@ -686,7 +686,7 @@ interactions:
       Connection:
       - keep-alive
       ParameterSetName:
-      - -g -t -r --config --schedule --defer-immediate-run
+      - -g -t -r --config --schedule
       User-Agent:
       - AZURECLI/2.61.0 azsdk-python-core/1.30.2 Python/3.8.10 (Windows-10-10.0.22631-SP0)
     method: GET

--- a/src/acrcssc/azext_acrcssc/tests/latest/test_cssc_scenario.py
+++ b/src/acrcssc/azext_acrcssc/tests/latest/test_cssc_scenario.py
@@ -20,16 +20,16 @@ from azure.cli.testsdk import (ScenarioTest, ResourceGroupPreparer)
 #         self.kwargs.update({
 #             'taskType': 'continuouspatchv1',
 #             'configpath': file_name,
-#             'cadence': '1d',
+#             'schedule': '1d',
 #             'registry':self.create_random_name(prefix='cli', length=24),
 #         })
 
 #         self.cmd('az acr create -g {rg} -n {registry} --sku Basic')
-#         self.cmd('az acr supply-chain workflow create -g {rg} -t {taskType} -r {registry} --config {configpath} --cadence {cadence} --defer-immediate-run'.format(**self.kwargs))
+#         self.cmd('az acr supply-chain workflow create -g {rg} -t {taskType} -r {registry} --config {configpath} --schedule {schedule} --defer-immediate-run'.format(**self.kwargs))
 #         cssc_tasks = self.cmd('az acr supply-chain workflow show -g {rg} -t {taskType} -r {registry}').get_output_in_json()
 #         # Verify all the cssc tasks are created
 #         assert len(cssc_tasks) == 3
 #         cssc_trigger_scan_task = next((task for task in cssc_tasks if task['name'] == 'cssc-trigger-scan'), None)
 #         # Verify cssc_trigger_scan_task properties
 #         assert cssc_trigger_scan_task is not None
-#         assert cssc_trigger_scan_task['cadence'] == '1d'
+#         assert cssc_trigger_scan_task['schedule'] == '1d'

--- a/src/acrcssc/azext_acrcssc/tests/latest/test_cssc_scenario.py
+++ b/src/acrcssc/azext_acrcssc/tests/latest/test_cssc_scenario.py
@@ -25,7 +25,7 @@ from azure.cli.testsdk import (ScenarioTest, ResourceGroupPreparer)
 #         })
 
 #         self.cmd('az acr create -g {rg} -n {registry} --sku Basic')
-#         self.cmd('az acr supply-chain workflow create -g {rg} -t {taskType} -r {registry} --config {configpath} --schedule {schedule} --defer-immediate-run'.format(**self.kwargs))
+#         self.cmd('az acr supply-chain workflow create -g {rg} -t {taskType} -r {registry} --config {configpath} --schedule {schedule}'.format(**self.kwargs))
 #         cssc_tasks = self.cmd('az acr supply-chain workflow show -g {rg} -t {taskType} -r {registry}').get_output_in_json()
 #         # Verify all the cssc tasks are created
 #         assert len(cssc_tasks) == 3

--- a/src/acrcssc/azext_acrcssc/tests/latest/test_helper_taskoperations.py
+++ b/src/acrcssc/azext_acrcssc/tests/latest/test_helper_taskoperations.py
@@ -35,6 +35,32 @@ class TestCreateContinuousPatchV1(unittest.TestCase):
         mock_convert_timespan_to_cron.assert_called_once_with("1d")
         mock_create_oci_artifact_continuous_patch.assert_called_once()
         mock_validate_and_deploy_template.assert_called_once()
+        mock_trigger_task_run.assert_not_called()
+        
+    @mock.patch("azext_acrcssc.helper._taskoperations.check_continuous_task_exists")
+    @mock.patch("azext_acrcssc.helper._taskoperations.convert_timespan_to_cron")
+    @mock.patch("azext_acrcssc.helper._taskoperations.create_oci_artifact_continuous_patch")
+    @mock.patch("azext_acrcssc.helper._taskoperations.parse_resource_id")
+    @mock.patch("azext_acrcssc.helper._taskoperations.validate_and_deploy_template")
+    @mock.patch("azext_acrcssc.helper._taskoperations._trigger_task_run")
+    def test_create_continuous_patch_v1_create_run_immediately_triggers_task(self, mock_trigger_task_run, mock_validate_and_deploy_template, mock_parse_resource_id, mock_create_oci_artifact_continuous_patch, mock_convert_timespan_to_cron, mock_check_continuoustask_exists):
+        # Mock the necessary dependencies
+        with tempfile.NamedTemporaryFile(delete=False) as temp_file:
+            temp_file_path = temp_file.name
+        mock_check_continuoustask_exists.return_value = False
+        mock_convert_timespan_to_cron.return_value = "0 0 * * *"
+        mock_parse_resource_id.return_value = {"resource_group": "test_rg"}
+        cmd = self._setup_cmd()
+        registry = mock.MagicMock()
+        registry.id = "/subscriptions/11111111-0000-0000-0000-0000000000006/resourceGroups/test-rg/providers/Microsoft.ContainerRegistry/registries/testregistry"
+
+        # Call the function
+        create_update_continuous_patch_v1(cmd, registry, temp_file_path, "1d", False, True)
+        
+        # Assert that the dependencies were called with the correct arguments
+        mock_convert_timespan_to_cron.assert_called_once_with("1d")
+        mock_create_oci_artifact_continuous_patch.assert_called_once()
+        mock_validate_and_deploy_template.assert_called_once()
         mock_trigger_task_run.assert_called_once()
 
     @mock.patch("azext_acrcssc.helper._taskoperations._update_task_schedule")
@@ -62,7 +88,7 @@ class TestCreateContinuousPatchV1(unittest.TestCase):
         mock_convert_timespan_to_cron.assert_called_once_with("2d")
         mock_create_oci_artifact_continuous_patch.assert_not_called()
         mock_validate_and_deploy_template.assert_not_called()
-        mock_trigger_task_run.assert_called_once()
+        mock_trigger_task_run.assert_not_called()
         mock_update_task_schedule.assert_called_once()
 
     @mock.patch("azext_acrcssc.helper._taskoperations.check_continuous_task_exists")
@@ -85,7 +111,35 @@ class TestCreateContinuousPatchV1(unittest.TestCase):
         
         # Assert that the dependencies were called with the correct arguments
         mock_convert_timespan_to_cron.assert_called_once_with("2d")
-        mock_create_oci_artifact_continuous_patch.not_called()
+        mock_create_oci_artifact_continuous_patch.assert_not_called()
+        
+    @mock.patch("azext_acrcssc.helper._taskoperations._update_task_schedule")
+    @mock.patch("azext_acrcssc.helper._taskoperations.check_continuous_task_exists")
+    @mock.patch("azext_acrcssc.helper._taskoperations.convert_timespan_to_cron")
+    @mock.patch("azext_acrcssc.helper._taskoperations.create_oci_artifact_continuous_patch")
+    @mock.patch("azext_acrcssc.helper._taskoperations.parse_resource_id")
+    @mock.patch("azext_acrcssc.helper._taskoperations.validate_and_deploy_template")
+    @mock.patch("azext_acrcssc.helper._taskoperations._trigger_task_run")
+    def test_update_continuous_patch_v1_schedule_update_run_immediately_triggers_task(self, mock_trigger_task_run, mock_validate_and_deploy_template, mock_parse_resource_id, mock_create_oci_artifact_continuous_patch, mock_convert_timespan_to_cron, mock_check_continuoustask_exists, mock_update_task_schedule):
+        # Mock the necessary dependencies
+        with tempfile.NamedTemporaryFile(delete=False) as temp_file:
+            temp_file_path = temp_file.name
+        mock_check_continuoustask_exists.return_value = True
+        mock_convert_timespan_to_cron.return_value = "0 0 * * *"
+        mock_parse_resource_id.return_value = {"resource_group": "test_rg"}
+        cmd = self._setup_cmd()
+        registry = mock.MagicMock()
+        registry.id = "/subscriptions/11111111-0000-0000-0000-0000000000006/resourceGroups/test-rg/providers/Microsoft.ContainerRegistry/registries/testregistry"
+
+        # Call the function
+        create_update_continuous_patch_v1(cmd, registry, None, "2d", False, True, False)
+        
+        # Assert that the dependencies were called with the correct arguments
+        mock_convert_timespan_to_cron.assert_called_once_with("2d")
+        mock_create_oci_artifact_continuous_patch.assert_not_called()
+        mock_validate_and_deploy_template.assert_not_called()
+        mock_trigger_task_run.assert_called_once()
+        mock_update_task_schedule.assert_called_once()
 
     @mock.patch("azext_acrcssc.helper._taskoperations.check_continuous_task_config_exists")
     @mock.patch('azext_acrcssc.helper._taskoperations.delete_oci_artifact_continuous_patch')

--- a/src/acrcssc/azext_acrcssc/tests/latest/test_helper_taskoperations.py
+++ b/src/acrcssc/azext_acrcssc/tests/latest/test_helper_taskoperations.py
@@ -44,7 +44,7 @@ class TestCreateContinuousPatchV1(unittest.TestCase):
     @mock.patch("azext_acrcssc.helper._taskoperations.parse_resource_id")
     @mock.patch("azext_acrcssc.helper._taskoperations.validate_and_deploy_template")
     @mock.patch("azext_acrcssc.helper._taskoperations._trigger_task_run")
-    def test_update_continuous_patch_v1_cadence_update_should_not_update_config(self, mock_trigger_task_run, mock_validate_and_deploy_template, mock_parse_resource_id, mock_create_oci_artifact_continuous_patch, mock_convert_timespan_to_cron, mock_check_continuoustask_exists, mock_update_task_schedule):
+    def test_update_continuous_patch_v1_schedule_update_should_not_update_config(self, mock_trigger_task_run, mock_validate_and_deploy_template, mock_parse_resource_id, mock_create_oci_artifact_continuous_patch, mock_convert_timespan_to_cron, mock_check_continuoustask_exists, mock_update_task_schedule):
         # Mock the necessary dependencies
         with tempfile.NamedTemporaryFile(delete=False) as temp_file:
             temp_file_path = temp_file.name

--- a/src/acrcssc/azext_acrcssc/tests/latest/test_validators.py
+++ b/src/acrcssc/azext_acrcssc/tests/latest/test_validators.py
@@ -110,8 +110,8 @@ class AcrCsscCommandsTests(unittest.TestCase):
                     "tags": ["v1"],
                     "enabled": True
                 }],
-            "version": "1"
-            }
+            "version": "v1"
+        }
         mock_load.return_value = mock_config
 
         with patch('os.path.exists', return_value=True), \
@@ -136,11 +136,46 @@ class AcrCsscCommandsTests(unittest.TestCase):
         mock_load.return_value = mock_invalid_config
 
         with patch('os.path.exists', return_value=True), \
-             patch('os.path.isfile', return_value=True), \
-             patch('os.path.getsize', return_value=100), \
-             patch('os.access', return_value=True):
-             self.assertRaises(AzCLIError, validate_continuouspatch_config_v1, temp_file_path)
-    
+            patch('os.path.isfile', return_value=True), \
+            patch('os.path.getsize', return_value=100), \
+            patch('os.access', return_value=True):
+            self.assertRaises(AzCLIError, validate_continuouspatch_config_v1, temp_file_path)
+
+    @patch('azext_acrcssc._validators.json.load')
+    def test_validate_continuouspatch_json_invalid_tags_should_fail(self, mock_load):
+        with tempfile.NamedTemporaryFile(delete=False) as temp_file:
+            temp_file_path = temp_file.name
+
+        mock_invalid_config = {
+            "repositories": [
+                {
+                    "repository": "docker-local",
+                    "tags": ["v1-patched"],
+                }],
+            }
+        mock_load.return_value = mock_invalid_config
+
+        with patch('os.path.exists', return_value=True), \
+            patch('os.path.isfile', return_value=True), \
+            patch('os.path.getsize', return_value=100), \
+            patch('os.access', return_value=True):
+            self.assertRaises(AzCLIError, validate_continuouspatch_config_v1, temp_file_path)
+
+        mock_invalid_config = {
+            "repositories": [
+                {
+                    "repository": "docker-local",
+                    "tags": ["v1-999"],
+                }],
+        }
+        mock_load.return_value = mock_invalid_config
+
+        with patch('os.path.exists', return_value=True), \
+            patch('os.path.isfile', return_value=True), \
+            patch('os.path.getsize', return_value=100), \
+            patch('os.access', return_value=True):
+            self.assertRaises(AzCLIError, validate_continuouspatch_config_v1, temp_file_path)
+
     def _setup_cmd(self):
         cmd = mock.MagicMock()
         cmd.cli_ctx = DummyCli()

--- a/src/acrcssc/azext_acrcssc/tests/latest/test_validators.py
+++ b/src/acrcssc/azext_acrcssc/tests/latest/test_validators.py
@@ -9,7 +9,7 @@ import unittest
 from unittest import mock
 from datetime import ( datetime,timezone)
 from ..._validators import (
-    _validate_cadence, check_continuous_task_exists, validate_continuouspatch_config_v1
+    _validate_schedule, check_continuous_task_exists, validate_continuouspatch_config_v1
 )
 
 from azure.cli.core.azclierror import AzCLIError, InvalidArgumentValueError
@@ -19,7 +19,7 @@ from unittest.mock import patch
 
 class AcrCsscCommandsTests(unittest.TestCase):
 
-    def test_validate_cadence_valid(self):
+    def test_validate_schedule_valid(self):
         test_cases = [
             ('1d' ),
             ('5d'),
@@ -28,13 +28,13 @@ class AcrCsscCommandsTests(unittest.TestCase):
 
         for timespan in test_cases:
             with self.subTest(timespan=timespan):
-               _validate_cadence(timespan)
+               _validate_schedule(timespan)
     
-    def test_validate_cadence_invalid(self):
+    def test_validate_schedule_invalid(self):
         test_cases = [('df'),('12'),('dd'),('41d'), ('21dd')]
 
         for timespan in test_cases:
-            self.assertRaises(InvalidArgumentValueError, _validate_cadence, timespan)
+            self.assertRaises(InvalidArgumentValueError, _validate_schedule, timespan)
 
 
     @patch('azext_acrcssc._validators.cf_acr_tasks')

--- a/src/acrcssc/setup.py
+++ b/src/acrcssc/setup.py
@@ -33,7 +33,7 @@ CLASSIFIERS = [
 ]
 
 # TODO: Add any additional SDK dependencies here
-DEPENDENCIES = ["oras~=0.1.19"]
+DEPENDENCIES = ["oras~=0.1.19", "croniter~=3.0.0"]
 
 with open('README.rst', 'r', encoding='utf-8') as f:
     README = f.read()

--- a/src/acrcssc/setup.py
+++ b/src/acrcssc/setup.py
@@ -16,7 +16,7 @@ except ImportError:
 
 # TODO: Confirm this is the right version number you want and it matches your
 # HISTORY.rst entry.
-VERSION = '1.0.0b1'
+VERSION = '1.0.0c1'
 
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers


### PR DESCRIPTION
Allow version values to be v1, no v2 needed
Add validation for tags in json to not end with reserved characters (-patched and -1 to -999)
Add a new property called tag-convention, with it being optional and default value as floating
Allowed values for tag-convention to be either incremental or floating
Defer run to run immediately flag flip
Change cadence to schedule
Show scheduled run time
Make schedule]as optional during update to allow for only config updates